### PR TITLE
Add League of Legends champion pool feature

### DIFF
--- a/cogs/games/league_of_legends/lolclashmodule.py
+++ b/cogs/games/league_of_legends/lolclashmodule.py
@@ -83,7 +83,7 @@ class lolclashmodule(commands.Cog, name="LoLClashModule", description="clashadd,
             beebot_profiles_data = beebot_profiles.get_beebot_profiles_json()
             # add member's roles
             beebot_profiles_data = beebot_profiles.beebot_profile_exists(
-                available_member, beebot_profiles_data)
+                beebot_profiles_data, available_member)
             beebot_profiles_data = beebot_profiles.beebot_profile_key_exists(
                 beebot_profiles_data, available_member, "league_of_legends")
             beebot_profiles_data[available_member]["league_of_legends"][

--- a/cogs/helper/constants/lol_constants.py
+++ b/cogs/helper/constants/lol_constants.py
@@ -57,8 +57,11 @@ def riot_ranks(): return {1: {'tier': 'IRON', 'rank': 'I'},
 def lol_keys(): return ['Q', 'W', 'E', 'R']
 
 
-def lol_roles(): return ['Top', 'Jung', 'Mid', 'Adc', 'Sup', 'Fill']
+def lol_roles(include_fill=True):
+    if include_fill:
+        return ['Top', 'Jung', 'Mid', 'Adc', 'Sup', 'Fill']
+    else:
+        return ['Top', 'Jung', 'Mid', 'Adc', 'Sup']
 
 
-def lol_tags(): return ['Fighter', 'Tank', 'Mage',
-                        'Assassin', 'Marksman', 'Support']
+def lol_tags(): return ['Fighter', 'Tank', 'Mage', 'Assassin', 'Marksman', 'Support']


### PR DESCRIPTION
This PR adds the champion pool feature to BeeBoy, which lets users add or remove champions they want to play in certain roles to their profiles to keep track of them. They can then view their champion pool or pick a random champion from a given role's pool.

The changes in this PR have not been tested yet since I don't have the API keys set up! Be sure to verify the functionality before merging and if anything is broken, we can fix it up together!